### PR TITLE
History Chart improvements

### DIFF
--- a/SprintCharts.py
+++ b/SprintCharts.py
@@ -425,6 +425,7 @@ class TaskChart(Chart):
 
 		self.plotOptions.line.dataLabels.enabled = not many
 		self.plotOptions.line.dataLabels.x = -10
+		self.plotOptions.line.step = True
 		self.legend.enabled = False
 		self.credits.enabled = False
 		with self.xAxis as x:
@@ -455,21 +456,7 @@ class TaskChart(Chart):
 
 			hoursByDay = dict((tsStripHours(rev.timestamp), rev.effectiveHours()) for rev in revs)
 			hoursByDay[tsStripHours(min(dateToTs(getNow()), task.historyEndsOn()))] = task.effectiveHours()
-
-			i = 0
-			sortedHoursByDay = sorted(hoursByDay.items())
-			series['data'] += [(utcToLocal(sortedHoursByDay[i][0]) * 1000, sortedHoursByDay[i][1])]
-			i += 1
-			# If there was no hours revision for a task on a given day, create a data point with the same hours as the previous day
-			# This prevents the graph from displaying hour deltas between two non-adjacent days
-			while i < len(sortedHoursByDay):
-				# MAGIC NUMBER: 8400000 is the length of a day in this time format
-				if (utcToLocal(sortedHoursByDay[i][0]) * 1000) - series['data'][-1][0] > 86400000:
-					series['data'] += [(series['data'][-1][0] + 86400000, series['data'][-1][1])]
-				else:
-					series['data'] += [(utcToLocal(sortedHoursByDay[i][0]) * 1000, sortedHoursByDay[i][1])]
-					i += 1
-
+			series['data'] += [(utcToLocal(date) * 1000, hours) for (date, hours) in sorted(hoursByDay.items())]
 
 
 class GroupGoalsChart(Chart):


### PR DESCRIPTION
1. Use standard line graph rather than a step graph so hour decrements make more sense visually (e.g., multiple decrements don't pile on top of each other into one vertical line). It makes the chart easier to read. Data points are added for each day regardless of whether there was an hours-revision on that day, so that a revision between two days correctly displays as a delta between those two days, rather than a delta between the current day and the last revision day.
2. Modify the ToolTip formatter to correctly display the information for overlapping points. For example, if multiple tasks have 8 hours remaining on the same day, hovering over that point will display the names of all tasks at that point, rather than just one lucky one.

These are only visual changes that do not affect current tasks/time/users/db/etc in a running instance. They can be pulled down and the tool restarted without breaking anything.
